### PR TITLE
export toCamelCase method

### DIFF
--- a/lib/snakeToCamelCase.js
+++ b/lib/snakeToCamelCase.js
@@ -22,3 +22,5 @@ function updateObject (object) {
 function toCamelCase (text) {
   return text.replace(/_(\w)/g, (_, character) => character.toUpperCase())
 }
+
+module.exports.toCamelCase = toCamelCase


### PR DESCRIPTION
Being able to access the camelcase logic in order to be able to use the exact same camelCase method from another place (i.e. the client that has to attribute the same camelcase logic to mach the transformed pattern) would be helpful.

Tested but please re-test on your side with your active implementations.